### PR TITLE
Add option to export grf file to JSON

### DIFF
--- a/PCK-Studio/Forms/Editor/GameRuleFileEditor.Designer.cs
+++ b/PCK-Studio/Forms/Editor/GameRuleFileEditor.Designer.cs
@@ -108,7 +108,6 @@
             this.GrfParametersTreeView.Name = "GrfParametersTreeView";
             this.GrfParametersTreeView.Size = new System.Drawing.Size(219, 312);
             this.GrfParametersTreeView.TabIndex = 1;
-            this.GrfParametersTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GrfParametersTreeView_AfterSelect);
             this.GrfParametersTreeView.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.GrfDetailsTreeView_NodeMouseDoubleClick);
             this.GrfParametersTreeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GrfDetailsTreeView_KeyDown);
             // 

--- a/PCK-Studio/Forms/Editor/GameRuleFileEditor.Designer.cs
+++ b/PCK-Studio/Forms/Editor/GameRuleFileEditor.Designer.cs
@@ -44,6 +44,7 @@
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportToJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compressionLvlToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.levelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.noneToolStripMenuItem = new PckStudio.ToolboxItems.ToolStripRadioButtonMenuItem();
@@ -55,6 +56,7 @@
             this.pS3ToolStripMenuItem = new PckStudio.ToolboxItems.ToolStripRadioButtonMenuItem();
             this.xbox360ToolStripMenuItem = new PckStudio.ToolboxItems.ToolStripRadioButtonMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
             this.MessageContextMenu.SuspendLayout();
             this.DetailContextMenu.SuspendLayout();
             this.menuStrip1.SuspendLayout();
@@ -77,9 +79,7 @@
             // 
             // MessageContextMenu
             // 
-            this.MessageContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addGameRuleToolStripMenuItem,
-            this.removeGameRuleToolStripMenuItem});
+            this.MessageContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { this.addGameRuleToolStripMenuItem, this.removeGameRuleToolStripMenuItem });
             this.MessageContextMenu.Name = "MessageContextMenu";
             this.MessageContextMenu.Size = new System.Drawing.Size(178, 48);
             // 
@@ -108,14 +108,13 @@
             this.GrfParametersTreeView.Name = "GrfParametersTreeView";
             this.GrfParametersTreeView.Size = new System.Drawing.Size(219, 312);
             this.GrfParametersTreeView.TabIndex = 1;
+            this.GrfParametersTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GrfParametersTreeView_AfterSelect);
             this.GrfParametersTreeView.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.GrfDetailsTreeView_NodeMouseDoubleClick);
             this.GrfParametersTreeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GrfDetailsTreeView_KeyDown);
             // 
             // DetailContextMenu
             // 
-            this.DetailContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addToolStripMenuItem1,
-            this.removeToolStripMenuItem});
+            this.DetailContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { this.addToolStripMenuItem1, this.removeToolStripMenuItem });
             this.DetailContextMenu.Name = "DetailContextMenu";
             this.DetailContextMenu.Size = new System.Drawing.Size(118, 48);
             // 
@@ -158,9 +157,7 @@
             // menuStrip1
             // 
             this.menuStrip1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem,
-            this.compressionLvlToolStripMenuItem});
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { this.fileToolStripMenuItem, this.compressionLvlToolStripMenuItem });
             this.menuStrip1.Location = new System.Drawing.Point(25, 60);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Size = new System.Drawing.Size(450, 24);
@@ -169,9 +166,7 @@
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openToolStripMenuItem,
-            this.saveToolStripMenuItem});
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.openToolStripMenuItem, this.saveToolStripMenuItem, this.exportToJSONToolStripMenuItem });
             this.fileToolStripMenuItem.ForeColor = System.Drawing.SystemColors.Menu;
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
@@ -180,7 +175,7 @@
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -188,15 +183,20 @@
             // 
             this.saveToolStripMenuItem.BackColor = System.Drawing.Color.Transparent;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
+            // exportToJSONToolStripMenuItem
+            // 
+            this.exportToJSONToolStripMenuItem.Name = "exportToJSONToolStripMenuItem";
+            this.exportToJSONToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
+            this.exportToJSONToolStripMenuItem.Text = "Export To JSON";
+            this.exportToJSONToolStripMenuItem.Click += new System.EventHandler(this.exportToJSONToolStripMenuItem_Click);
+            // 
             // compressionLvlToolStripMenuItem
             // 
-            this.compressionLvlToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.levelToolStripMenuItem,
-            this.typeToolStripMenuItem});
+            this.compressionLvlToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.levelToolStripMenuItem, this.typeToolStripMenuItem });
             this.compressionLvlToolStripMenuItem.ForeColor = System.Drawing.SystemColors.Menu;
             this.compressionLvlToolStripMenuItem.Name = "compressionLvlToolStripMenuItem";
             this.compressionLvlToolStripMenuItem.Size = new System.Drawing.Size(89, 20);
@@ -205,11 +205,7 @@
             // levelToolStripMenuItem
             // 
             this.levelToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.levelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.noneToolStripMenuItem,
-            this.compressedToolStripMenuItem,
-            this.compressedRLEToolStripMenuItem,
-            this.compressedRLECRCToolStripMenuItem});
+            this.levelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.noneToolStripMenuItem, this.compressedToolStripMenuItem, this.compressedRLEToolStripMenuItem, this.compressedRLECRCToolStripMenuItem });
             this.levelToolStripMenuItem.Name = "levelToolStripMenuItem";
             this.levelToolStripMenuItem.Size = new System.Drawing.Size(101, 22);
             this.levelToolStripMenuItem.Text = "Level";
@@ -251,10 +247,7 @@
             // typeToolStripMenuItem
             // 
             this.typeToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.typeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.wiiUPSVitaToolStripMenuItem,
-            this.pS3ToolStripMenuItem,
-            this.xbox360ToolStripMenuItem});
+            this.typeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.wiiUPSVitaToolStripMenuItem, this.pS3ToolStripMenuItem, this.xbox360ToolStripMenuItem });
             this.typeToolStripMenuItem.Name = "typeToolStripMenuItem";
             this.typeToolStripMenuItem.Size = new System.Drawing.Size(101, 22);
             this.typeToolStripMenuItem.Text = "Type";
@@ -293,9 +286,7 @@
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.Controls.Add(this.metroLabel1, 0, 0);
@@ -309,6 +300,13 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.Size = new System.Drawing.Size(450, 312);
             this.tableLayoutPanel1.TabIndex = 4;
+            // 
+            // saveFileDialog1
+            // 
+            this.saveFileDialog1.DefaultExt = "json";
+            this.saveFileDialog1.Filter = "JSON File|*.json";
+            this.saveFileDialog1.Title = "Export to JSON";
+            this.saveFileDialog1.FileOk += new System.ComponentModel.CancelEventHandler(this.saveFileDialog1_FileOk);
             // 
             // GameRuleFileEditor
             // 
@@ -337,8 +335,11 @@
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
+
+        private System.Windows.Forms.SaveFileDialog saveFileDialog1;
+
+        private System.Windows.Forms.ToolStripMenuItem exportToJSONToolStripMenuItem;
 
         #endregion
 

--- a/PCK-Studio/Forms/Editor/GameRuleFileEditor.cs
+++ b/PCK-Studio/Forms/Editor/GameRuleFileEditor.cs
@@ -17,8 +17,11 @@
 **/
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using Newtonsoft.Json;
 using PckStudio.Forms.Additional_Popups.Grf;
 using PckStudio.Internal.Misc;
 using OMI.Formats.GameRule;
@@ -267,6 +270,25 @@ namespace PckStudio.Forms.Editor
             {
                 saveToolStripMenuItem_Click(sender, EventArgs.Empty);
             }
+        }
+
+        private void exportToJSONToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            saveFileDialog1.FileName = "gameRules.json";
+            saveFileDialog1.ShowDialog();
+        }
+
+        private void saveFileDialog1_FileOk(object sender, CancelEventArgs e)
+        {
+            if (saveFileDialog1.FileName == "")
+            {
+                return;
+            }
+
+            TextWriter writer = new StreamWriter(saveFileDialog1.FileName);
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Formatting = Formatting.Indented;
+            serializer.Serialize(writer, _file.Root.ChildRules);
         }
     }
 }

--- a/PCK-Studio/Forms/Editor/GameRuleFileEditor.cs
+++ b/PCK-Studio/Forms/Editor/GameRuleFileEditor.cs
@@ -289,6 +289,7 @@ namespace PckStudio.Forms.Editor
             JsonSerializer serializer = new JsonSerializer();
             serializer.Formatting = Formatting.Indented;
             serializer.Serialize(writer, _file.Root.ChildRules);
+            writer.Flush();
         }
     }
 }

--- a/PCK-Studio/Forms/Editor/GameRuleFileEditor.resx
+++ b/PCK-Studio/Forms/Editor/GameRuleFileEditor.resx
@@ -126,6 +126,9 @@
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>348, 17</value>
   </metadata>
+  <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>454, 18</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
I added an option to export the data from a game rule file to a json file for use in other applications / tools.
This is a feature I really needed for one of my projects, and I figured it could be useful to other people also.

In the grf editor I added File > Export to JSON to the menubar
![image](https://github.com/user-attachments/assets/cf093829-6373-4f51-94c4-07bf075d5862)
 
Here is a sample of the generated JSON
```json
[
  {
    "Name": "MapOptions",
    "Parameters": {
      "seed": "-5069382193672799790",
      "spawnX": "-62",
      "spawnY": "212",
      "spawnZ": "208",
      "flatworld": "false",
      "worldName": "IDS_ICARUS_WORLD_NAME",
      "worldDescription": "IDS_ICARUS_DESCRIPTION",
      "worldPreviewImage": "WorldSave/Icarus.png",
      "baseSaveName": "Icarus_MG03.mcs",
      "mapSize": "0",
      "themeId": "14",
      "texturePackId": "1031"
    },
    "ChildRules": []
  },
  {
    "Name": "LevelRules",
    "Parameters": {
      "ruleType": "3"
    },
    "ChildRules": [
      {
        "Name": "ActiveChunkArea",
        "Parameters": {
          "name": "Box - 1",
          "x0": "-3",
          "z0": "-23",
          "x1": "-1",
          "z1": "-18"
        },
        "ChildRules": []
      },
(4014 more lines...)
```

See the sister pull request in [-OMI-Filetype-Library](https://github.com/PhoenixARC/-OMI-Filetype-Library)
